### PR TITLE
[Mod] Hunting Mission Upgrade

### DIFF
--- a/MMOCoreORB/src/server/zone/managers/mission/MissionManagerImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/managers/mission/MissionManagerImplementation.cpp
@@ -1370,24 +1370,56 @@ void MissionManagerImplementation::randomizeGenericHuntingMission(CreatureObject
 	mission->setMissionTargetName(creatureTemplate->getObjectName());
 	mission->setTargetTemplate(sharedTemplate);
 
-	//50% easy missions, 33% medium missions, 17% hard missions.
+	// 50% easy missions, 33% medium missions, 17% hard missions.
 	int difficulty = System::random(5) + 1;
 	String diffString;
+	
+	// Difficulty based on the number of creatures
 	if (difficulty <= 3) {
 		difficulty = 1;
-		diffString = "easy";
+		diffString = "easy"; // 15 animals
 	} else if (difficulty <= 5) {
 		difficulty = 2;
-		diffString = "medium";
+		diffString = "medium"; // 30 animals
 	} else {
 		difficulty = 3;
-		diffString = "hard";
+		diffString = "hard"; // 45 animals
 	}
+	
+	// Prevent every mission for same animal type from having almost exactly the same payout.
+	float diffRange = randomLairSpawn->getMaxDifficulty() - randomLairSpawn->getMinDifficulty() + 1.0f;
+	
+	float creatureLevelPart = 12900.0f * (MIN(90.0f + System::random(9.0f), (float)randomLairSpawn->getMinDifficulty() + System::random(diffRange)) / 99.0f);
+	float critterNumberPart = 100.0f; // 100 only used if randomLairSpawn->getMaxDifficulty() is null/broken
+	
+	// Throttle bonus for num of creatures based on how easy they are to kill
+	if (randomLairSpawn->getMaxDifficulty() < 12) {
+		critterNumberPart = 1000.0f * ((float)difficulty / 3.0f);
+	} else if (randomLairSpawn->getMaxDifficulty() < 45){
+		critterNumberPart = 5000.0f * ((float)difficulty / 3.0f);
+	} else if (randomLairSpawn->getMaxDifficulty() < 65){
+		critterNumberPart = 8000.0f * ((float)difficulty / 3.0f);
+	} else if (randomLairSpawn->getMaxDifficulty() > 64) {
+		critterNumberPart = 12000.0f * ((float)difficulty / 3.0f);
+	}
+	
+	float initialReward = creatureLevelPart + critterNumberPart + System::random(100.0f); // 12,900 + 12,000 + 100 = 25,000
+	
+	// Scout and Ranger bonuses
+	float forageBonus = initialReward * (MIN(125.0f, player->getSkillMod("foraging") + 1.0f) / 1250.0f); // Upto +10% = 2,500
+	float knowledgeBonus = initialReward * (MIN(125.0f, player->getSkillMod("creature_knowledge") + 1.0f) / 1250.0f); // Upto +10% = 2,500
+	
+	// Max possible payout: 30,000 Credits
+	float finalReward = initialReward + forageBonus + knowledgeBonus;
 
-	int baseReward = 500 + (difficulty * 100 * randomLairSpawn->getMinDifficulty());
-	mission->setRewardCredits(baseReward + System::random(100));
+	mission->setRewardCredits((int)finalReward);
 	mission->setMissionDifficulty(difficulty);
-	mission->setMissionTitle("mission/mission_npc_hunting_neutral_" + diffString, "m" + String::valueOf(randTexts) + "t");
+
+	// Format short desc text so output looks like [CL12]: Kill 45 nuna
+	UnicodeString mobName = StringIdManager::instance()->getStringId(String::hashCode(creatureTemplate->getObjectName()));
+	String details = " Kill " + String::valueOf(difficulty * 15) + " " + mobName.toString().replaceAll("a ", "");
+	
+	mission->setHuntingMissionTitle("CL" + String::valueOf(randomLairSpawn->getMaxDifficulty()), details);
 	mission->setMissionDescription("mission/mission_npc_hunting_neutral_" + diffString, "m" + String::valueOf(randTexts) + "o");
 
 	mission->setTypeCRC(MissionTypes::HUNTING);

--- a/MMOCoreORB/src/server/zone/objects/mission/HuntingMissionObjectiveImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/mission/HuntingMissionObjectiveImplementation.cpp
@@ -20,6 +20,12 @@
 #include "server/zone/objects/mission/MissionObject.h"
 #include "server/zone/objects/mission/MissionObserver.h"
 #include "server/zone/objects/creature/ai/CreatureTemplate.h"
+#include "server/zone/managers/player/PlayerManager.h"
+
+#include "server/zone/packets/DeltaMessage.h"
+#include "server/zone/packets/mission/MissionObjectMessage3.h"
+#include "server/zone/packets/mission/MissionObjectDeltaMessage3.h"
+
 
 void HuntingMissionObjectiveImplementation::activate() {
 	MissionObjectiveImplementation::activate();
@@ -59,6 +65,19 @@ void HuntingMissionObjectiveImplementation::abort() {
 void HuntingMissionObjectiveImplementation::complete() {
 
 	MissionObjectiveImplementation::complete();
+	
+	//Award Wilderness Survival XP.
+	ManagedReference<MissionObject* > mission = this->mission.get();
+	ManagedReference<CreatureObject*> owner = getPlayerOwner();
+	
+	float diversityBonus = 0.0f; // Bonus for having more Scout/Ranger branches/SEAs
+	int trappingSkill = owner->getSkillMod("trapping");
+	
+	if (trappingSkill > 0)
+		diversityBonus= 2000.0f * (float)(MIN(125, trappingSkill) / 100); 
+	
+	int xp = mission->getRewardCredits() / 3 + (float)diversityBonus;
+	owner->getZoneServer()->getPlayerManager()->awardExperience(owner, "camp", xp, true, 1);
 }
 
 int HuntingMissionObjectiveImplementation::notifyObserverEvent(MissionObserver* observer, uint32 eventType, Observable* observable, ManagedObject* arg1, int64 arg2) {
@@ -97,6 +116,9 @@ int HuntingMissionObjectiveImplementation::notifyObserverEvent(MissionObserver* 
 			message.setTO(mission->getTargetName());
 
 			getPlayerOwner().get()->sendSystemMessage(message);
+			
+			// Change mission description in datapad for easy tracking of progress.
+			mission->updateHuntingMissionDescription(" To complete this mission you must eliminate " + String::valueOf(targetsKilled) + " more creatures.");
 		}
 	}
 

--- a/MMOCoreORB/src/server/zone/objects/mission/MissionObject.idl
+++ b/MMOCoreORB/src/server/zone/objects/mission/MissionObject.idl
@@ -157,6 +157,10 @@ class MissionObject extends IntangibleObject {
 	@preLocked
 	public native void setMissionTitle(final string file, final string id, boolean notifyClient = true);
 	@preLocked
+	public native void setHuntingMissionTitle(final string difficulty, final string name, boolean notifyClient = true);
+	@preLocked
+	public native void updateHuntingMissionDescription(final string message, boolean notifyClient = true);
+	@preLocked
 	public native void setMissionTargetName(final string target, boolean notifyClient = true);
 	public native void setMissionDifficulty(int diffLevel, boolean notifyClient = true);
 	@preLocked

--- a/MMOCoreORB/src/server/zone/objects/mission/MissionObjectImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/mission/MissionObjectImplementation.cpp
@@ -108,6 +108,46 @@ void MissionObjectImplementation::setMissionTitle(const String& file, const Stri
 	}
 }
 
+
+// Make the mission title useful: [Level #]: Kill ## Animal Name 
+void MissionObjectImplementation::setHuntingMissionTitle(const String& difficulty, const String& name, bool notifyClient) {
+	Locker clocker(waypointToMission, _this.getReferenceUnsafeStaticCast());
+
+	waypointToMission->setCustomObjectName(missionTitle.getFullPath(), false);
+
+	clocker.release();
+
+	if (!notifyClient)
+		return;
+
+	ManagedReference<SceneObject*> player = getParentRecursively(SceneObjectType::PLAYERCREATURE);
+
+	if (player != NULL) {
+		MissionObjectDeltaMessage3* delta = new MissionObjectDeltaMessage3(_this.getReferenceUnsafeStaticCast());
+		delta->updateHuntingMissionTitle(difficulty, name);
+		delta->close();
+
+		player->sendMessage(delta);
+	}
+}
+
+// Make the description in the datapad useful by showing how many animals are left to kill.
+void MissionObjectImplementation::updateHuntingMissionDescription(const String& message, bool notifyClient) {
+
+	if (!notifyClient)
+		return;
+
+	ManagedReference<SceneObject*> player = getParentRecursively(SceneObjectType::PLAYERCREATURE);
+
+	if (player != NULL) {
+		MissionObjectDeltaMessage3* delta = new MissionObjectDeltaMessage3(_this.get());
+		delta->updateHuntingMissionDescription(message);
+		delta->close();
+
+		player->sendMessage(delta);
+	}
+}
+
 void MissionObjectImplementation::setMissionTargetName(const String& target, bool notifyClient) {
 	targetName = target;
 

--- a/MMOCoreORB/src/server/zone/packets/mission/MissionObjectDeltaMessage3.h
+++ b/MMOCoreORB/src/server/zone/packets/mission/MissionObjectDeltaMessage3.h
@@ -25,6 +25,14 @@ public:
 		insertInt(0);
 		insertAscii(stringId->getStringID());
 	}
+	
+	void updateHuntingMissionDescription(const String& message) {
+		startUpdate(0x0B);
+
+		insertAscii("Current Mission Status");
+		insertInt(0);
+		insertAscii(message);
+	}
 
 	void updateTitleStf(StringId* stringId) {
 		startUpdate(0x0C);
@@ -32,6 +40,14 @@ public:
 		insertAscii(stringId->getFile());
 		insertInt(0);
 		insertAscii(stringId->getStringID());
+	}
+	
+	void updateHuntingMissionTitle(const String& difficulty, const String& name) {
+		startUpdate(0x0C);
+
+		insertAscii(difficulty);
+		insertInt(0);
+		insertAscii(name);
 	}
 
 	void updateTargetName(const String& name) {


### PR DESCRIPTION
- Credit payouts scale much better with creature level and kill requirement.
- Mission completion grants Wilderness Survival XP.
- Foraging, Trapping, and Creature Knowledge skill (up to 125 with "skill tapes") effect credit and XP rewards.
- Mission browser description field now looks like [CL12]: Kill 45 Nuna.
- Datapad desciption, when the window is opened, gets updated to show how many kills are left after each kill. Logging out resets it to the roleplay description until the next kill.
